### PR TITLE
Konfigurer auto.offset.reset som none.

### DIFF
--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -20,7 +20,8 @@
     "LAGRE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
     "SLETTE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
     "JOURNALFORE_SCOPES": "b32ae17c-0276-4006-9507-4ef49e0e5e20/.default",
-    "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443"
+    "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
+    "KAFKA_AUTO_OFFSET_RESET": "none"
   },
   "slack-channel": "sif-alerts-dev",
   "slack-notify-type": "<!here> | k9-ettersending-prosessering | "

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -19,7 +19,8 @@
     "LAGRE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "SLETTE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "JOURNALFORE_SCOPES": "cb751642-883c-48d3-9f82-06cc72c3e4b9/.default",
-    "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443"
+    "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
+    "KAFKA_AUTO_OFFSET_RESET": "none"
   },
   "slack-channel": "sif-alerts",
   "slack-notify-type": "<!channel> | k9-ettersending-prosessering | "

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -30,6 +30,14 @@ data class Configuration(private val config: ApplicationConfig) {
                 }
             }
 
+            val autoOffsetReset = when(val offsetReset = config.getOptionalString(key = "nav.kafka.auto_offset_reset", secret = false)?.toLowerCase()) {
+                null -> "none"
+                "none" -> offsetReset
+                "latest" -> offsetReset
+                "earliest" -> offsetReset
+                else -> throw IllegalArgumentException("Ugyldig verdi for nav.kafka.auto_offset_reset: $offsetReset")
+            }
+
             KafkaConfig(
                 bootstrapServers = bootstrapServers,
                 credentials = Pair(
@@ -38,6 +46,7 @@ data class Configuration(private val config: ApplicationConfig) {
                 ),
                 trustStore = trustStore,
                 exactlyOnce = trustStore != null,
+                autoOffsetReset = autoOffsetReset,
                 unreadyAfterStreamStoppedIn = unreadyAfterStreamStoppedIn()
             )
         }

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -8,6 +8,7 @@ import no.nav.helse.dusseldorf.ktor.core.getRequiredString
 import no.nav.helse.kafka.KafkaConfig
 import java.net.URI
 import java.time.Duration
+import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
 
 @KtorExperimentalAPI
@@ -21,6 +22,8 @@ data class Configuration(private val config: ApplicationConfig) {
         config.getRequiredString("nav.kafka.unready_after_stream_stopped_in.amount", secret = false).toLong(),
         ChronoUnit.valueOf(config.getRequiredString("nav.kafka.unready_after_stream_stopped_in.unit", secret = false))
     )
+
+    internal fun soknadDatoMottattEtter() = ZonedDateTime.parse(config.getRequiredString("nav.prosesser_soknader_mottatt_etter", secret = false))
 
     internal fun getKafkaConfig() =
         config.getRequiredString("nav.kafka.bootstrap_servers", secret = false).let { bootstrapServers ->

--- a/src/main/kotlin/no/nav/helse/K9EttersendingProsessering.kt
+++ b/src/main/kotlin/no/nav/helse/K9EttersendingProsessering.kt
@@ -36,6 +36,7 @@ import no.nav.helse.prosessering.v1.asynkron.AsynkronProsesseringV1Service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.URI
+import java.time.ZonedDateTime
 
 private val logger: Logger = LoggerFactory.getLogger("nav.K9EttersendingProsessering")
 
@@ -81,7 +82,8 @@ fun Application.k9EttersendingProsessering() {
         kafkaConfig = configuration.getKafkaConfig(),
         preprosseseringV1Service = preprosseseringV1Service,
         joarkGateway = joarkGateway,
-        dokumentService = dokumentService
+        dokumentService = dokumentService,
+        datoMottattEtter = configuration.soknadDatoMottattEtter()
     )
 
     environment.monitor.subscribe(ApplicationStopping) {
@@ -123,6 +125,8 @@ fun Application.k9EttersendingProsessering() {
 }
 
 private fun Url.Companion.healthURL(baseUrl: URI) = Url.buildURL(baseUrl = baseUrl, pathParts = listOf("health"))
+
+fun ZonedDateTime.erEtter(zonedDateTime: ZonedDateTime): Boolean = this.isAfter(zonedDateTime)
 
 internal fun ObjectMapper.k9EttersendingKonfigurert() = dusseldorfConfigured()
     .setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE)

--- a/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
@@ -20,12 +20,13 @@ internal class KafkaConfig(
     credentials: Pair<String, String>,
     trustStore: Pair<String, String>?,
     exactlyOnce: Boolean,
+    autoOffsetReset: String,
     internal val unreadyAfterStreamStoppedIn: Duration
 ) {
     private val streams = Properties().apply {
         put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
         put(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndFailExceptionHandler::class.java)
-        put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+        put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset)
         medCredentials(credentials)
         medTrustStore(trustStore)
         medProcessingGuarantee(exactlyOnce)

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/AsynkronProsesseringV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/AsynkronProsesseringV1Service.kt
@@ -5,12 +5,14 @@ import no.nav.helse.joark.JoarkGateway
 import no.nav.helse.kafka.KafkaConfig
 import no.nav.helse.prosessering.v1.PreprosseseringV1Service
 import org.slf4j.LoggerFactory
+import java.time.ZonedDateTime
 
 internal class AsynkronProsesseringV1Service(
     kafkaConfig: KafkaConfig,
     preprosseseringV1Service: PreprosseseringV1Service,
     joarkGateway: JoarkGateway,
-    dokumentService: DokumentService
+    dokumentService: DokumentService,
+    datoMottattEtter: ZonedDateTime
 ) {
 
     private companion object {
@@ -20,19 +22,22 @@ internal class AsynkronProsesseringV1Service(
     private val preprosseseringStreamEttersending =
         PreprosseseringStreamEttersending(
             kafkaConfig = kafkaConfig,
-            preprosseseringV1Service = preprosseseringV1Service
+            preprosseseringV1Service = preprosseseringV1Service,
+            datoMottattEtter = datoMottattEtter
         )
 
     private val journalforingsStreamEttersending =
         JournalføringStreamEttersending(
             kafkaConfig = kafkaConfig,
-            joarkGateway = joarkGateway
+            joarkGateway = joarkGateway,
+            datoMottattEtter = datoMottattEtter
         )
 
     private val cleanupStreamEttersending =
         CleanupStreamEttersending(
             kafkaConfig = kafkaConfig,
-            dokumentService = dokumentService
+            dokumentService = dokumentService,
+            datoMottattEtter = datoMottattEtter
         )
 
     private val healthChecks = setOf(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,6 +9,8 @@ ktor {
     }
 }
 nav {
+    prosesser_soknader_mottatt_etter = "2020-11-05T00:00:00.000+01"
+    prosesser_soknader_mottatt_etter = ${?PROSESSER_SOKNADER_MOTTATT_ETTER}
     k9_dokument_base_url = ""
     k9_dokument_base_url = ${?K9_DOKUMENT_BASE_URL}
     K9_JOARK_BASE_URL = ""

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -47,6 +47,8 @@ nav {
         username = ${?NAIS_username}
         password = ""
         password = ${?NAIS_password},
+        auto_offset_reset = ""
+        auto_offset_reset = ${?KAFKA_AUTO_OFFSET_RESET}
         unready_after_stream_stopped_in = {
             amount = "15"
             unit = "MINUTES"

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -47,6 +47,7 @@ object TestConfiguration {
             map["nav.kafka.bootstrap_servers"] = it.brokersURL
             map["nav.kafka.username"] = it.username()
             map["nav.kafka.password"] = it.password()
+            map["nav.kafka.auto_offset_reset"] = "earliest"
         }
 
         return map.toMap()


### PR DESCRIPTION
Vil gi en exception dersom kafka server ikke finner offset for consumer.
Dette hindrer consumer fra å hoppe til latest eller earliest offset dersom kafkaserver ikke skulle offset for consumer.