### PR TITLE
Fikser NoOffsetForPartitionException for cleanupstream.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,9 +60,7 @@ dependencies {
 }
 
 repositories {
-    maven("https://dl.bintray.com/kotlin/ktor")
-    maven("https://kotlin.bintray.com/kotlinx")
-    maven("http://packages.confluent.io/maven/")
+    mavenLocal()
 
     maven {
         name = "GitHubPackages"
@@ -73,9 +71,12 @@ repositories {
         }
     }
 
-    jcenter()
-    mavenLocal()
     mavenCentral()
+    jcenter()
+
+    maven("https://dl.bintray.com/kotlin/ktor")
+    maven("https://kotlin.bintray.com/kotlinx")
+    maven("http://packages.confluent.io/maven/")
 }
 
 

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -20,7 +20,7 @@
     "SLETTE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "JOURNALFORE_SCOPES": "cb751642-883c-48d3-9f82-06cc72c3e4b9/.default",
     "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
-    "KAFKA_AUTO_OFFSET_RESET": "none"
+    "KAFKA_AUTO_OFFSET_RESET": "earliest"
   },
   "slack-channel": "sif-alerts",
   "slack-notify-type": "<!channel> | k9-ettersending-prosessering | "

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -24,6 +24,8 @@ data class Configuration(private val config: ApplicationConfig) {
     )
 
     internal fun soknadDatoMottattEtter() = ZonedDateTime.parse(config.getRequiredString("nav.prosesser_soknader_mottatt_etter", secret = false))
+    internal fun journalførMeldingDatoMottattEtter() = ZonedDateTime.parse(config.getRequiredString("nav.journalfor_meldinger_mottatt_etter", secret = false))
+    internal fun cleanupMeldingDatoMottattEtter() = ZonedDateTime.parse(config.getRequiredString("nav.cleanup_meldinger_mottatt_etter", secret = false))
 
     internal fun getKafkaConfig() =
         config.getRequiredString("nav.kafka.bootstrap_servers", secret = false).let { bootstrapServers ->

--- a/src/main/kotlin/no/nav/helse/K9EttersendingProsessering.kt
+++ b/src/main/kotlin/no/nav/helse/K9EttersendingProsessering.kt
@@ -83,7 +83,9 @@ fun Application.k9EttersendingProsessering() {
         preprosseseringV1Service = preprosseseringV1Service,
         joarkGateway = joarkGateway,
         dokumentService = dokumentService,
-        datoMottattEtter = configuration.soknadDatoMottattEtter()
+        preprosesserMeldingerMottattEtter = configuration.soknadDatoMottattEtter(),
+        cleanupMeldingDatoMottattEtter = configuration.cleanupMeldingDatoMottattEtter(),
+        journalførMeldingDatoMottattEtter = configuration.journalførMeldingDatoMottattEtter()
     )
 
     environment.monitor.subscribe(ApplicationStopping) {

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/AsynkronProsesseringV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/AsynkronProsesseringV1Service.kt
@@ -12,7 +12,9 @@ internal class AsynkronProsesseringV1Service(
     preprosseseringV1Service: PreprosseseringV1Service,
     joarkGateway: JoarkGateway,
     dokumentService: DokumentService,
-    datoMottattEtter: ZonedDateTime
+    preprosesserMeldingerMottattEtter: ZonedDateTime,
+    cleanupMeldingDatoMottattEtter: ZonedDateTime,
+    journalførMeldingDatoMottattEtter: ZonedDateTime
 ) {
 
     private companion object {
@@ -23,21 +25,21 @@ internal class AsynkronProsesseringV1Service(
         PreprosseseringStreamEttersending(
             kafkaConfig = kafkaConfig,
             preprosseseringV1Service = preprosseseringV1Service,
-            datoMottattEtter = datoMottattEtter
+            datoMottattEtter = preprosesserMeldingerMottattEtter
         )
 
     private val journalforingsStreamEttersending =
         JournalføringStreamEttersending(
             kafkaConfig = kafkaConfig,
             joarkGateway = joarkGateway,
-            datoMottattEtter = datoMottattEtter
+            datoMottattEtter = journalførMeldingDatoMottattEtter
         )
 
     private val cleanupStreamEttersending =
         CleanupStreamEttersending(
             kafkaConfig = kafkaConfig,
             dokumentService = dokumentService,
-            datoMottattEtter = datoMottattEtter
+            datoMottattEtter = cleanupMeldingDatoMottattEtter
         )
 
     private val healthChecks = setOf(

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,9 +9,9 @@ ktor {
     }
 }
 nav {
-    prosesser_soknader_mottatt_etter = "2021-02-01T21:27:05.000+01"
+    prosesser_soknader_mottatt_etter = "2021-02-02T09:05:30.000+01"
     prosesser_soknader_mottatt_etter = ${?PROSESSER_SOKNADER_MOTTATT_ETTER}
-    journalfor_meldinger_mottatt_etter = "2021-02-01T21:27:05.000+01"
+    journalfor_meldinger_mottatt_etter = "2021-02-02T09:05:30.000+01"
     journalfor_meldinger_mottatt_etter = ${?JOURNALFOR_MELDINGER_MOTTATT_ETTER}
     cleanup_meldinger_mottatt_etter = "2021-02-01T18:29:27.000+01"
     cleanup_meldinger_mottatt_etter = ${?CLEANUP_MELDINGER_MOTTATT_ETTER}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -9,8 +9,12 @@ ktor {
     }
 }
 nav {
-    prosesser_soknader_mottatt_etter = "2020-11-05T00:00:00.000+01"
+    prosesser_soknader_mottatt_etter = "2021-02-01T21:27:05.000+01"
     prosesser_soknader_mottatt_etter = ${?PROSESSER_SOKNADER_MOTTATT_ETTER}
+    journalfor_meldinger_mottatt_etter = "2021-02-01T21:27:05.000+01"
+    journalfor_meldinger_mottatt_etter = ${?JOURNALFOR_MELDINGER_MOTTATT_ETTER}
+    cleanup_meldinger_mottatt_etter = "2021-02-01T18:29:27.000+01"
+    cleanup_meldinger_mottatt_etter = ${?CLEANUP_MELDINGER_MOTTATT_ETTER}
     k9_dokument_base_url = ""
     k9_dokument_base_url = ${?K9_DOKUMENT_BASE_URL}
     K9_JOARK_BASE_URL = ""


### PR DESCRIPTION
Setter KAFKA_AUTO_OFFSET_RESET til earliest og leser meldinger etter sist suksessfulle konsumerte meldinger etter angitte datoer:
* preprosessering: 2021-02-02T09:05:30
* journalføring: 2021-02-02T09:05:30
* cleanup: 2021-02-01T18:29:27

Logg: 
* Siste [preprosesserte meldinger](https://logs.adeo.no/goto/7af2a15117598477a5bc719384af05a3)
* Siste [journalførte meldinger](https://logs.adeo.no/goto/e8add8df4a6eadcd69c2f43cac62aab7)
* Siste [cleanup meldinger](https://logs.adeo.no/goto/dde862c5cccf28b04cc7f799e5c331fc)