### PR TITLE
Legger til støtte for å forholde seg til vedleggId i stedet for vedleggUrls. 

### DIFF
--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -16,7 +16,6 @@ data class Configuration(private val config: ApplicationConfig) {
     fun getk9JoarkBaseUrl() = URI(config.getRequiredString("nav.K9_JOARK_BASE_URL", secret = false))
     fun getK9MellomlagringBaseUrl() = URI(config.getRequiredString("nav.k9_mellomlagring_base_url", secret = false))
 
-
     private fun unreadyAfterStreamStoppedIn() = Duration.of(
         config.getRequiredString("nav.kafka.unready_after_stream_stopped_in.amount", secret = false).toLong(),
         ChronoUnit.valueOf(config.getRequiredString("nav.kafka.unready_after_stream_stopped_in.unit", secret = false))

--- a/src/main/kotlin/no/nav/helse/joark/JoarkGateway.kt
+++ b/src/main/kotlin/no/nav/helse/joark/JoarkGateway.kt
@@ -91,6 +91,10 @@ class JoarkGateway(
 
         val authorizationHeader = cachedAccessTokenClient.getAccessToken(journalforeScopes).asAuthoriationHeader()
 
+        val dokumentId = preprosessertEttersending.dokumentUrls.map {
+            it.map { it.toString().substringAfterLast("/") }
+        }
+
         val joarkRequest = JoarkRequest(
             norskIdent = preprosessertEttersending.søker.fødselsnummer,
             mottatt = preprosessertEttersending.mottatt,
@@ -99,7 +103,7 @@ class JoarkGateway(
                 mellomnavn = preprosessertEttersending.søker.mellomnavn,
                 etternavn = preprosessertEttersending.søker.etternavn
             ),
-            dokumenter = preprosessertEttersending.dokumentUrls
+            dokumentId = dokumentId
         )
 
         val body = objectMapper.writeValueAsBytes(joarkRequest)
@@ -160,7 +164,7 @@ private data class JoarkRequest(
     @JsonProperty("norsk_ident") val norskIdent: String,
     val mottatt: ZonedDateTime,
     @JsonProperty("soker_navn") val søkerNavn: Navn,
-    val dokumenter: List<List<URI>>
+    val dokumentId: List<List<String>>
 )
 
 data class Navn(

--- a/src/main/kotlin/no/nav/helse/joark/JoarkGateway.kt
+++ b/src/main/kotlin/no/nav/helse/joark/JoarkGateway.kt
@@ -91,10 +91,6 @@ class JoarkGateway(
 
         val authorizationHeader = cachedAccessTokenClient.getAccessToken(journalforeScopes).asAuthoriationHeader()
 
-        val dokumentId = preprosessertEttersending.dokumentUrls.map {
-            it.map { it.toString().substringAfterLast("/") }
-        }
-
         val joarkRequest = JoarkRequest(
             norskIdent = preprosessertEttersending.søker.fødselsnummer,
             mottatt = preprosessertEttersending.mottatt,
@@ -103,7 +99,7 @@ class JoarkGateway(
                 mellomnavn = preprosessertEttersending.søker.mellomnavn,
                 etternavn = preprosessertEttersending.søker.etternavn
             ),
-            dokumentId = dokumentId
+            dokumentId = preprosessertEttersending.vedleggId
         )
 
         val body = objectMapper.writeValueAsBytes(joarkRequest)

--- a/src/main/kotlin/no/nav/helse/joark/JoarkGateway.kt
+++ b/src/main/kotlin/no/nav/helse/joark/JoarkGateway.kt
@@ -164,7 +164,7 @@ private data class JoarkRequest(
     @JsonProperty("norsk_ident") val norskIdent: String,
     val mottatt: ZonedDateTime,
     @JsonProperty("soker_navn") val søkerNavn: Navn,
-    val dokumentId: List<List<String>>
+    @JsonProperty("dokument_id") val dokumentId: List<List<String>>
 )
 
 data class Navn(

--- a/src/main/kotlin/no/nav/helse/k9mellomlagring/K9MellomlagringGateway.kt
+++ b/src/main/kotlin/no/nav/helse/k9mellomlagring/K9MellomlagringGateway.kt
@@ -132,17 +132,22 @@ class K9MellomlagringGateway(
     }
 
     internal suspend fun slettDokmenter(
-        urls: List<URI>,
+        vedleggId: List<String>,
         dokumentEier: DokumentEier,
         correlationId: CorrelationId
     ) {
         val authorizationHeader = cachedAccessTokenClient.getAccessToken(k9MellomlagringScopes).asAuthoriationHeader()
         coroutineScope {
             val deferred = mutableListOf<Deferred<Unit>>()
-            urls.forEach {
+            vedleggId.forEach {vedleggId ->
                 deferred.add(async {
+                    val url = Url.buildURL(
+                        baseUrl = completeUrl,
+                        pathParts = listOf(vedleggId)
+                    )
+
                     requestSlettDokument(
-                        url = it,
+                        url = url,
                         correlationId = correlationId,
                         dokumentEier = dokumentEier,
                         authorizationHeader = authorizationHeader

--- a/src/main/kotlin/no/nav/helse/k9mellomlagring/K9MellomlagringService.kt
+++ b/src/main/kotlin/no/nav/helse/k9mellomlagring/K9MellomlagringService.kt
@@ -18,12 +18,12 @@ class K9MellomlagringService(
     }
 
     internal suspend fun slettDokumeter(
-        urlBolks: List<List<URI>>,
+        vedleggIdBolks: List<List<String>>,
         dokumentEier: DokumentEier,
         correlationId : CorrelationId
     ) {
         k9MellomlagringGateway.slettDokmenter(
-            urls = urlBolks.flatten(),
+            vedleggId = vedleggIdBolks.flatten(),
             dokumentEier = dokumentEier,
             correlationId = correlationId
         )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
@@ -79,7 +79,7 @@ internal class PdfV1Generator {
                         ),
                         "beskrivelse" to melding.beskrivelse,
                         "vedleggUrls" to mapOf(
-                            "vedlegg" to melding.vedleggUrls.somMapVedleggUrls()
+                            "vedlegg" to melding.vedleggUrls?.somMapVedleggUrls()
                         ),
                         "søknadstype" to melding.søknadstype.pdfNavn,
                         "samtykke" to mapOf(

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PdfV1Generator.kt
@@ -14,7 +14,6 @@ import no.nav.helse.prosessering.v1.felles.Søker
 import no.nav.helse.prosessering.v1.felles.norskDag
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
-import java.net.URI
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -78,9 +77,6 @@ internal class PdfV1Generator {
                             "fødselsnummer" to melding.søker.fødselsnummer
                         ),
                         "beskrivelse" to melding.beskrivelse,
-                        "vedleggUrls" to mapOf(
-                            "vedlegg" to melding.vedleggUrls?.somMapVedleggUrls()
-                        ),
                         "søknadstype" to melding.søknadstype.pdfNavn,
                         "samtykke" to mapOf(
                             "harForståttRettigheterOgPlikter" to melding.harForståttRettigheterOgPlikter,
@@ -138,14 +134,6 @@ internal class PdfV1Generator {
                 BaseRendererBuilder.FontStyle.ITALIC,
                 false
             )
-}
-
-private fun List<URI>.somMapVedleggUrls(): List<Map<String, Any?>> {
-    return map {
-        mapOf(
-            "navn" to it
-        )
-    }
 }
 
 private fun List<String>.somMapTitler(): List<Map<String, Any?>> {

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/PreprosseseringV1Service.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/PreprosseseringV1Service.kt
@@ -42,7 +42,7 @@ internal class PreprosseseringV1Service(
                 title = ettersending.søknadstype.somDokumentbeskrivelse()
             ),
             correlationId = correlationId,
-        ).vedleggIdFraUrl()
+        ).vedleggId()
 
         logger.info("Mellomlagrer Oppsummerings-JSON")
         val ettersendingJsonVedleggId = k9MellomlagringService.lagreDokument(
@@ -53,7 +53,7 @@ internal class PreprosseseringV1Service(
                 title = "Ettersendelse ${ettersending.søknadstype} som JSON"
             ),
             correlationId = correlationId
-        ).vedleggIdFraUrl()
+        ).vedleggId()
 
         val komplettVedleggId = mutableListOf(
             listOf(
@@ -69,7 +69,7 @@ internal class PreprosseseringV1Service(
             if(ettersending.vedleggUrls != null && ettersending.vedleggUrls.isNotEmpty()){
                 logger.info("Legger til ${ettersending.vedleggUrls.size} vedlegg id's fra meldingen som dokument.")
                 logger.info("Mapper om vedleggUrls fra melding til vedleggId")
-                ettersending.vedleggUrls.forEach { komplettVedleggId.add(listOf(it.vedleggIdFraUrl())) }
+                ettersending.vedleggUrls.forEach { komplettVedleggId.add(listOf(it.vedleggId())) }
             }
         }
 
@@ -84,7 +84,7 @@ internal class PreprosseseringV1Service(
     }
 }
 
-fun URI.vedleggIdFraUrl(): String = this.toString().substringAfterLast("/")
+fun URI.vedleggId(): String = this.toString().substringAfterLast("/")
 
 private fun Søknadstype.somDokumentbeskrivelse(): String {
     return when (this) {

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/CleanupStreamEttersending.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/CleanupStreamEttersending.kt
@@ -48,7 +48,7 @@ internal class CleanupStreamEttersending(
                         logger.info("Sletter ettersending dokumenter.")
                         val cleanupEttersending = entry.deserialiserTilCleanup()
                         k9MellomlagringService.slettDokumeter(
-                            urlBolks = cleanupEttersending.melding.dokumentUrls,
+                            vedleggIdBolks = cleanupEttersending.melding.vedleggId,
                             correlationId = CorrelationId(entry.metadata.correlationId),
                             dokumentEier = DokumentEier(cleanupEttersending.melding.søker.fødselsnummer)
                         )

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/JournalføringStreamEttersending.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/asynkron/JournalføringStreamEttersending.kt
@@ -49,13 +49,13 @@ internal class JournalføringStreamEttersending(
                     process(NAME, soknadId, entry) {
                         val preprosessertEttersending = entry.deserialiserTilPreprosessertMelding()
 
-                        logger.info("Journalfører dokumenter: {}", preprosessertEttersending.dokumentUrls)
+                        logger.info("Journalfører dokumenter: {}", preprosessertEttersending.vedleggId)
                         val journaPostId = joarkGateway.journalførEttersending(
                             correlationId = CorrelationId(entry.metadata.correlationId),
                             preprosessertEttersending = preprosessertEttersending
                         )
-                        logger.info("Dokumenter journalført med ID = ${journaPostId.journalpostId}.")
 
+                        logger.info("Dokumenter journalført med ID = ${journaPostId.journalpostId}.")
                         val journalfort = JournalfortEttersending(
                             journalpostId = journaPostId.journalpostId,
                             søknad = preprosessertEttersending.k9Format

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/ettersending/EttersendingV1.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/ettersending/EttersendingV1.kt
@@ -10,7 +10,8 @@ data class EttersendingV1(
     val søknadId: String,
     val mottatt: ZonedDateTime,
     val språk: String? = "nb",
-    val vedleggUrls: List<URI>,
+    val vedleggUrls: List<URI>?, // TODO: 07/01/2022 Fjernes når api kun sender vedleggId
+    val vedleggId: List<String>?,
     val harForståttRettigheterOgPlikter: Boolean,
     val harBekreftetOpplysninger: Boolean,
     val beskrivelse: String?,

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/ettersending/PreprosessertEttersendingV1.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/ettersending/PreprosessertEttersendingV1.kt
@@ -2,13 +2,12 @@ package no.nav.helse.prosessering.v1.ettersending
 
 import no.nav.helse.prosessering.v1.felles.Søker
 import no.nav.k9.ettersendelse.Ettersendelse
-import java.net.URI
 import java.time.ZonedDateTime
 
 data class PreprosessertEttersendingV1(
     val sprak: String?,
     val soknadId: String,
-    val dokumentUrls: List<List<URI>>,
+    val vedleggId: List<List<String>>,
     val mottatt: ZonedDateTime,
     val søker: Søker,
     val harForstattRettigheterOgPlikter: Boolean,
@@ -20,11 +19,11 @@ data class PreprosessertEttersendingV1(
 ) {
     internal constructor(
         melding: EttersendingV1,
-        dokumentUrls: List<List<URI>>
+        vedleggId: List<List<String>>
     ) : this(
         sprak = melding.språk,
         soknadId = melding.søknadId,
-        dokumentUrls = dokumentUrls,
+        vedleggId = vedleggId,
         mottatt = melding.mottatt,
         søker = melding.søker,
         beskrivelse = melding.beskrivelse,

--- a/src/main/kotlin/no/nav/helse/prosessering/v1/ettersending/PreprosessertEttersendingV1Metrics.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/ettersending/PreprosessertEttersendingV1Metrics.kt
@@ -12,5 +12,5 @@ private val antallVedleggHistogram = Histogram.build()
 internal fun PreprosessertEttersendingV1.reportMetrics() {
     antallVedleggHistogram
         .labels(søknadstype.name) ////TODO 23.03.2021 - Må oppdatere Grafana til å støtte nytt navn
-        .observe(dokumentUrls.size.toDouble()-1) //Minus 1 fordi også oppsummeringPDF blir lagt i dokumentUrls
+        .observe(vedleggId.size.toDouble()-1) //Minus 1 fordi også oppsummeringPDF blir lagt i dokumentUrls
 }

--- a/src/test/kotlin/no/nav/helse/EttersendingUtils.kt
+++ b/src/test/kotlin/no/nav/helse/EttersendingUtils.kt
@@ -3,19 +3,14 @@ package no.nav.helse
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.helse.prosessering.v1.ettersending.EttersendingV1
 import no.nav.helse.prosessering.v1.ettersending.Søknadstype
-import no.nav.helse.prosessering.v1.felles.DAGER_SYNLIG_K9BESKJED
 import no.nav.helse.prosessering.v1.felles.Søker
-import no.nav.helse.prosessering.v1.felles.somK9BeskjedYtelse
 import no.nav.k9.ettersendelse.Ettersendelse
 import no.nav.k9.ettersendelse.Ytelse
 import no.nav.k9.søknad.felles.type.NorskIdentitetsnummer
 import no.nav.k9.søknad.felles.type.SøknadId
-import org.json.JSONObject
-import java.net.URI
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.*
-import kotlin.test.assertEquals
 
 internal object EttersendingUtils {
     internal val objectMapper = jacksonObjectMapper().k9EttersendingKonfigurert()
@@ -39,11 +34,8 @@ internal object EttersendingUtils {
                 "Sed accumsan erat cursus enim aliquet, ac auctor orci consequat. " +
                 "Etiam nec tellus sapien. Nam gravida massa id sagittis ultrices.",
         søknadstype = Søknadstype.OMP_UTV_KS,
-        vedleggUrls = listOf(
-            URI("http://localhost:8081/vedlegg1"),
-            URI("http://localhost:8081/vedlegg2"),
-            URI("http://localhost:8081/vedlegg3")
-        ),
+        vedleggId = listOf("vedlegg1", "vedlegg2", "vedlegg3"),
+        vedleggUrls = null,
         titler = listOf("Vedlegg 1", "Vedlegg 2", "Vedlegg 3"),
         k9Format = Ettersendelse.builder()
             .søknadId(SøknadId(søknadId))
@@ -55,13 +47,3 @@ internal object EttersendingUtils {
 }
 
 internal fun EttersendingV1.somJson() = EttersendingUtils.objectMapper.writeValueAsString(this)
-
-internal fun String.assertGyldigK9Beskjed(ettersending: EttersendingV1) {
-    val k9Beskjed = JSONObject(this)
-    val ytelse = ettersending.søknadstype.somK9BeskjedYtelse()
-
-    assertEquals(ettersending.søknadId, k9Beskjed.getString("grupperingsId"))
-    assertEquals(ytelse.tekst, k9Beskjed.getString("tekst"))
-    assertEquals(ytelse.toString(), k9Beskjed.getString("ytelse"))
-    assertEquals(DAGER_SYNLIG_K9BESKJED, k9Beskjed.getLong("dagerSynlig"))
-}


### PR DESCRIPTION
Sender med vedleggId/dokumentId ved journalføring.

Støtter begge varianter i overgangsfasen.

